### PR TITLE
Implement task 2

### DIFF
--- a/AsyncAwait.Task2.CodeReviewChallenge/Controllers/HomeController.cs
+++ b/AsyncAwait.Task2.CodeReviewChallenge/Controllers/HomeController.cs
@@ -27,13 +27,13 @@ public class HomeController : Controller
 
     public ActionResult Privacy()
     {
-        ViewBag.Message = _privacyDataService.GetPrivacyDataAsync().Result;
+        ViewBag.Message = _privacyDataService.GetPrivacyData();
         return View();
     }
 
     public async Task<IActionResult> Help()
     {
-        ViewBag.RequestInfo = await _assistant.RequestAssistanceAsync("guest").ConfigureAwait(false);
+        ViewBag.RequestInfo = await _assistant.RequestAssistanceAsync("guest");
         return View();
     }
 

--- a/AsyncAwait.Task2.CodeReviewChallenge/Models/Support/IAssistant.cs
+++ b/AsyncAwait.Task2.CodeReviewChallenge/Models/Support/IAssistant.cs
@@ -4,5 +4,5 @@ namespace AsyncAwait.Task2.CodeReviewChallenge.Models.Support;
 
 public interface IAssistant
 {
-    Task<string> RequestAssistanceAsync(string requestInfo);
+    ValueTask<string> RequestAssistanceAsync(string requestInfo);
 }

--- a/AsyncAwait.Task2.CodeReviewChallenge/Models/Support/ManualAssistant.cs
+++ b/AsyncAwait.Task2.CodeReviewChallenge/Models/Support/ManualAssistant.cs
@@ -15,20 +15,16 @@ public class ManualAssistant : IAssistant
         _supportService = supportService ?? throw new ArgumentNullException(nameof(supportService));
     }
 
-    public async Task<string> RequestAssistanceAsync(string requestInfo)
+    public async ValueTask<string> RequestAssistanceAsync(string requestInfo)
     {
         try
         {
-            var t = _supportService.RegisterSupportRequestAsync(requestInfo);
-            Console.WriteLine(t.Status); // this is for debugging purposes
-            Thread.Sleep(5000); // this is just to be sure that the request is registered
-            return await _supportService.GetSupportInfoAsync(requestInfo)
-                .ConfigureAwait(false);
+            await _supportService.RegisterSupportRequestAsync(requestInfo);
+            return await _supportService.GetSupportInfoAsync(requestInfo);
         }
         catch (HttpRequestException ex)
         {
-            return await Task.Run(async () =>
-                await Task.FromResult($"Failed to register assistance request. Please try later. {ex.Message}"));
+            return $"Failed to register assistance request. Please try later. {ex.Message}";
         }
     }
 }

--- a/AsyncAwait.Task2.CodeReviewChallenge/Services/IPrivacyDataService.cs
+++ b/AsyncAwait.Task2.CodeReviewChallenge/Services/IPrivacyDataService.cs
@@ -4,5 +4,5 @@ namespace AsyncAwait.Task2.CodeReviewChallenge.Services;
 
 public interface IPrivacyDataService
 {
-    Task<string> GetPrivacyDataAsync();
+    string GetPrivacyData();
 }

--- a/AsyncAwait.Task2.CodeReviewChallenge/Services/PrivacyDataService.cs
+++ b/AsyncAwait.Task2.CodeReviewChallenge/Services/PrivacyDataService.cs
@@ -4,9 +4,9 @@ namespace AsyncAwait.Task2.CodeReviewChallenge.Services;
 
 public class PrivacyDataService : IPrivacyDataService
 {
-    public Task<string> GetPrivacyDataAsync()
+    public string GetPrivacyData()
     {
-        return new ValueTask<string>("This Policy describes how async/await processes your personal data," +
-                                     "but it may not address all possible data processing scenarios.").AsTask();
+        return "This Policy describes how async/await processes your personal data," +
+               "but it may not address all possible data processing scenarios.";
     }
 }


### PR DESCRIPTION
### PrivacyDataServiceService.cs
 - GetPrivacyData returns a string const, no need for asynchronous tasks here even if it returns a ValueTask! I converted it to a simple method, however, it would be even better to move it just to a const field.
### ManualAssistant.cs
 - Blocking the RequestAssistanceAsync method with Thread.Sleep call is a bad practice, simply awaiting the  _supportService.RegisterSupportRequestAsync method call achieves the same goal in a non-blocking way.
 - In the case of HttpRequestException thrown we return a const string, this makes me think of changing the return type of the method to ValueTask to reduce memory allocation for this scenario.
### General
 - Configure await is redundant in the asp.net core.